### PR TITLE
Allow TimedTouchSwitch to work with floats

### DIFF
--- a/Code/TimedTouchSwitch.cs
+++ b/Code/TimedTouchSwitch.cs
@@ -43,7 +43,7 @@ namespace Celeste.Mod.OutbackHelper
 		
 		public TimedTouchSwitch(EntityData data, Vector2 offset) : base(data.Position + offset)
 		{
-			startDisappearTime = (float)data.Enum("startDisappearTime", DisappearTimes.Slow);
+			startDisappearTime = data.Float("startDisappearTime", (float) data.Enum("startDisappearTime", DisappearTimes.Slow));
             icon = new Sprite(GFX.Game, "collectables/outback/timedtouchswitch/idle");
             Remove(Get<Sprite>());
             Add(icon);

--- a/Code/TimedTouchSwitch.cs
+++ b/Code/TimedTouchSwitch.cs
@@ -43,7 +43,7 @@ namespace Celeste.Mod.OutbackHelper
 		
 		public TimedTouchSwitch(EntityData data, Vector2 offset) : base(data.Position + offset)
 		{
-			startDisappearTime = data.Float("startDisappearTime", (float) data.Enum("startDisappearTime", DisappearTimes.Slow));
+			startDisappearTime = Math.Max(data.Float("startDisappearTime", (float) data.Enum("startDisappearTime", DisappearTimes.Slow)), 0f);
             icon = new Sprite(GFX.Game, "collectables/outback/timedtouchswitch/idle");
             Remove(Get<Sprite>());
             Add(icon);

--- a/Loenn/entities/timedtouchswitch.lua
+++ b/Loenn/entities/timedtouchswitch.lua
@@ -23,6 +23,13 @@ for timeName, time in pairs(times) do
     })
 end
 
+tts.fieldInformation = {
+    startDisappearTime = {
+        fieldType = "number",
+        minimumValue = 0
+    }
+}
+
 local containerTexture = "collectables/outback/timedtouchswitch/cont"
 local iconTexture = "collectables/outback/timedtouchswitch/idle00"
 


### PR DESCRIPTION
Currently `"startDisappearTime"` is parsed as an Enum using `data.Enum`, which behind the scenes uses `System.Enum.TryParse` which accepts either a string representation of the enum or an integer value, but the loenn UI lets the mapper set any number, so if you enter a float value it will fail to parse it an default to `DisappearTimes.Slow`.

This PR limits the input in Loenn to just positive numbers and now `TimedTouchSwitch` tries to parse the value from `EntityData` as a float as well in order to let mappers set float values to there timed switches.