### PR TITLE
Smooth transition when entering portals

### DIFF
--- a/Code/OutbackModule.cs
+++ b/Code/OutbackModule.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using Microsoft.Xna.Framework;
 using Monocle;
 
@@ -6,6 +7,15 @@ namespace Celeste.Mod.OutbackHelper
 {
     public class OutbackModule : EverestModule
     {
+        public static OutbackModule Instance;
+
+        public OutbackModule() {
+            Instance = this;
+        }
+
+        public override Type SettingsType => typeof(OutbackModuleSettings);
+        public static OutbackModuleSettings Settings => (OutbackModuleSettings) Instance._Settings;
+
         public static SpriteBank SpriteBank;
     
         private static FieldInfo pufferPushRadius = typeof(Puffer).GetField("pushRadius", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -86,6 +96,42 @@ namespace Celeste.Mod.OutbackHelper
                 }
             }
             return true;
+        }
+    }
+
+    public class OutbackModuleSettings : EverestModuleSettings
+    {
+        public enum FreezeTimerValues
+        {
+            None,
+            VeryShort,
+            Short,
+            Medium,
+            Long,
+            VeryLong
+        }
+
+        public FreezeTimerValues DefaultPortalFreezeTime { get; set; } = FreezeTimerValues.None;
+
+        public float FreezeTime {
+            get {
+                switch (DefaultPortalFreezeTime) {
+                    case FreezeTimerValues.None:
+                        return 0f;
+                    case FreezeTimerValues.VeryShort:
+                        return 0.1f;
+                    case FreezeTimerValues.Short:
+                        return 0.2f;
+                    case FreezeTimerValues.Medium:
+                        return 0.3f;
+                    case FreezeTimerValues.Long:
+                        return 0.5f;
+                    case FreezeTimerValues.VeryLong:
+                        return 1f;
+                    default:
+                        return 0f;
+                }
+            }
         }
     }
 }

--- a/Code/OutbackModule.cs
+++ b/Code/OutbackModule.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -125,27 +125,14 @@ namespace Celeste.Mod.OutbackHelper
             VeryLong
         }
 
+        public static float[] FreezeTimerInSeconds = new float[] {
+            0f, 0.1f, 0.2f, 0.3f, 0.5f, 1f
+        };
+
         public FreezeTimerValues DefaultPortalFreezeTime { get; set; } = FreezeTimerValues.None;
 
         public float FreezeTime {
-            get {
-                switch (DefaultPortalFreezeTime) {
-                    case FreezeTimerValues.None:
-                        return 0f;
-                    case FreezeTimerValues.VeryShort:
-                        return 0.1f;
-                    case FreezeTimerValues.Short:
-                        return 0.2f;
-                    case FreezeTimerValues.Medium:
-                        return 0.3f;
-                    case FreezeTimerValues.Long:
-                        return 0.5f;
-                    case FreezeTimerValues.VeryLong:
-                        return 1f;
-                    default:
-                        return 0f;
-                }
-            }
+            get => FreezeTimerInSeconds[(int)DefaultPortalFreezeTime];
         }
     }
 }

--- a/Code/OutbackModule.cs
+++ b/Code/OutbackModule.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Microsoft.Xna.Framework;
 using Monocle;
@@ -26,6 +26,20 @@ namespace Celeste.Mod.OutbackHelper
         {
             Everest.Events.Level.OnLoadEntity += new Everest.Events.Level.LoadEntityHandler(this.OnLoadEntity);
             On.Celeste.Puffer.Explode += Puffer_Explode;
+            Portal.P_PortalLine = new ParticleType
+            {
+                Color = Color.White,
+                Color2 = Color.White * 0.7f,
+                ColorMode = ParticleType.ColorModes.Blink,
+                FadeMode = ParticleType.FadeModes.Late,
+                LifeMin = 0.3f,
+                LifeMax = 0.7f,
+                Size = 1f,
+                SpeedMin = 10f,
+                SpeedMax = 20f,
+                Acceleration = new Vector2(0f, 8f),
+                DirectionRange = 0.5f,
+            };
         }
 
         public override void LoadContent(bool firstLoad)

--- a/Code/Portal.cs
+++ b/Code/Portal.cs
@@ -277,21 +277,21 @@ namespace Celeste.Mod.OutbackHelper {
         }
 
         private IEnumerator Transport(Player player, Vector2 cameraFrom) {
-            // this.AddTag(Tags.FrozenUpdate);
             this.level.Frozen = true;
             float transportAt = 0f;
             Vector2 cameraTo = this.level.GetFullCameraTargetAt(player, player.Position);
-            while (transportAt < 1f) {
-                yield return null;
-                transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / freezeCooldown);
-                if (transportAt > 0.9f) {
-                    this.level.Camera.Position = cameraTo;
-                } else {
+            float distanceSq = Vector2.DistanceSquared(cameraFrom, cameraTo);
+            if (distanceSq > 100f) {
+                while (transportAt < 1f) {
+                    yield return null;
+                    transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / freezeCooldown);
                     this.level.Camera.Position = Vector2.Lerp(cameraFrom, cameraTo, Ease.CubeOut(transportAt));
                 }
+            } else {
+                yield return freezeCooldown;
             }
+            this.level.Camera.Position = cameraTo;
             this.level.OnEndOfFrame += delegate() {
-                // this.RemoveTag(Tags.FrozenUpdate);
                 this.level.Frozen = false;
             };
             yield break;

--- a/Code/Portal.cs
+++ b/Code/Portal.cs
@@ -263,6 +263,7 @@ namespace Celeste.Mod.OutbackHelper {
                 }
                 Audio.Play("event:/char/badeline/disappear", player.Position);
                 base.Add(new Coroutine(this.Transport(player, cameraFrom), true));
+                base.Add(new Coroutine(this.EmitLine(), true));
                 this.level.Displacement.AddBurst(this.otherPortal.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Displacement.AddBurst(this.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Particles.Emit(Player.P_Split, 16, this.otherPortal.Center, Vector2.One * 6f);
@@ -277,23 +278,52 @@ namespace Celeste.Mod.OutbackHelper {
         }
 
         private IEnumerator Transport(Player player, Vector2 cameraFrom) {
+            // TODO division by 0
             this.level.Frozen = true;
             float transportAt = 0f;
             Vector2 cameraTo = this.level.GetFullCameraTargetAt(player, player.Position);
-            float distanceSq = Vector2.DistanceSquared(cameraFrom, cameraTo);
-            if (distanceSq > 100f) {
+            if (Vector2.Distance(cameraFrom, cameraTo) > 50f) {
                 while (transportAt < 1f) {
                     yield return null;
                     transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / realFreezeTime);
                     this.level.Camera.Position = Vector2.Lerp(cameraFrom, cameraTo, Ease.CubeOut(transportAt));
                 }
+                this.level.Camera.Position = cameraTo;
             } else {
                 yield return realFreezeTime;
             }
-            this.level.Camera.Position = cameraTo;
             this.level.OnEndOfFrame += delegate() {
                 this.level.Frozen = false;
             };
+            yield break;
+        }
+
+        private IEnumerator EmitLine() {
+            float lineDirection = Calc.Angle(this.Position, this.otherPortal.Position);
+            float lineLength = Vector2.Distance(this.Position, this.otherPortal.Position);
+
+            float emitAt = 0f;
+            float nextFrameEmitAt = 0f;
+            // how much to advance each frame, roughly 1.5 times faster than linear
+            float emitAtFrame = realFreezeTime <= 0.05f ? 1f :
+                Math.Min(Engine.DeltaTime / realFreezeTime, 1f);
+            // How much to advace each step, to keep constant spacing of 10 pixels
+            float emitAtStep = Calc.Clamp(0.00001f, 10f / lineLength, 0.2f);
+            // A guard to prevent dead loops
+            int emitCount = 0;
+            while (emitCount < 1000000 & emitAt < 1f) {
+                yield return null;
+                nextFrameEmitAt += emitAtFrame;
+                while (emitCount < 10000 & emitAt < Ease.CubeOut(nextFrameEmitAt)) {
+                    emitCount ++;
+                    emitAt += emitAtStep;
+                    this.level.ParticlesFG.Emit(
+                        P_PortalLine, 1,
+                        Vector2.Lerp(this.Position, this.otherPortal.Position, emitAt),
+                        Vector2.One * 2f,
+                        lineDirection);
+                }
+            }
             yield break;
         }
 
@@ -428,5 +458,8 @@ namespace Celeste.Mod.OutbackHelper {
 
             Right
         }
+
+
+        public static ParticleType P_PortalLine;
     }
 }

--- a/Code/Portal.cs
+++ b/Code/Portal.cs
@@ -22,7 +22,7 @@ namespace Celeste.Mod.OutbackHelper {
             base.Depth = -9999;
             this.portal = base.Get<Sprite>();
             this.maxCooldown = data.Float("cooldownTimer", 0f);
-            this.freezeCooldown = data.Float("freezeTimer", 0.5f);
+            this.freezeCooldown = data.Float("freezeTimer", -1f);
             base.Add(this.portal = OutbackModule.SpriteBank.Create("portal"));
             base.Add(new PlayerCollider(new Action<Player>(this.OnPlayer), null, new Hitbox(30f, 30f, -15f, -15f)));
             this.portal.CenterOrigin();
@@ -266,10 +266,10 @@ namespace Celeste.Mod.OutbackHelper {
                 this.level.Displacement.AddBurst(this.otherPortal.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Displacement.AddBurst(this.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Particles.Emit(Player.P_Split, 16, this.otherPortal.Center, Vector2.One * 6f);
-                portal.teleportInsideCooldown = 0.5f + freezeCooldown;
-                this.teleportInsideCooldown = 0.5f + freezeCooldown;
-                portal.cooldown = portal.maxCooldown + freezeCooldown;
-                this.cooldown = this.maxCooldown + freezeCooldown;
+                portal.teleportInsideCooldown = 0.5f + realFreezeTime;
+                this.teleportInsideCooldown = 0.5f + realFreezeTime;
+                portal.cooldown = portal.maxCooldown + realFreezeTime;
+                this.cooldown = this.maxCooldown + realFreezeTime;
                 portal.portal.Color = this.cooldownColor;
                 this.portal.Color = this.cooldownColor;
                 this.level.Session.SetFlag("portalOnCooldown" + readyColor.ToString(), true);
@@ -284,11 +284,11 @@ namespace Celeste.Mod.OutbackHelper {
             if (distanceSq > 100f) {
                 while (transportAt < 1f) {
                     yield return null;
-                    transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / freezeCooldown);
+                    transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / realFreezeTime);
                     this.level.Camera.Position = Vector2.Lerp(cameraFrom, cameraTo, Ease.CubeOut(transportAt));
                 }
             } else {
-                yield return freezeCooldown;
+                yield return realFreezeTime;
             }
             this.level.Camera.Position = cameraTo;
             this.level.OnEndOfFrame += delegate() {
@@ -365,6 +365,11 @@ namespace Celeste.Mod.OutbackHelper {
 
 
         public float freezeCooldown = 0f;
+
+
+        private float realFreezeTime {
+            get => freezeCooldown < 0f ? OutbackModule.Settings.FreezeTime : freezeCooldown;
+        }
 
 
         public float teleportInsideCooldown;

--- a/Code/Portal.cs
+++ b/Code/Portal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Xna.Framework;
@@ -21,9 +22,11 @@ namespace Celeste.Mod.OutbackHelper {
             base.Depth = -9999;
             this.portal = base.Get<Sprite>();
             this.maxCooldown = data.Float("cooldownTimer", 0f);
+            this.freezeCooldown = data.Float("freezeTimer", 0.5f);
             base.Add(this.portal = OutbackModule.SpriteBank.Create("portal"));
             base.Add(new PlayerCollider(new Action<Player>(this.OnPlayer), null, new Hitbox(30f, 30f, -15f, -15f)));
             this.portal.CenterOrigin();
+            base.Tag = Tags.FrozenUpdate;
             bool flag = this.direction == 0;
             if (flag) {
                 this.portal.Play("idle", true, false);
@@ -172,6 +175,7 @@ namespace Celeste.Mod.OutbackHelper {
         private void OnPlayer(Player player) {
             bool flag = this.teleportInsideCooldown <= 0f && otherPortal != null;
             if (flag) {
+                Vector2 cameraFrom = this.level.Camera.Position;
                 Portal portal = (Portal)this.otherPortal;
                 bool flag2 = this.direction == 0;
                 if (flag2) {
@@ -258,17 +262,39 @@ namespace Celeste.Mod.OutbackHelper {
                     }
                 }
                 Audio.Play("event:/char/badeline/disappear", player.Position);
+                base.Add(new Coroutine(this.Transport(player, cameraFrom), true));
                 this.level.Displacement.AddBurst(this.otherPortal.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Displacement.AddBurst(this.Position, 0.35f, 8f, 48f, 0.25f, null, null);
                 this.level.Particles.Emit(Player.P_Split, 16, this.otherPortal.Center, Vector2.One * 6f);
-                portal.teleportInsideCooldown = 0.5f;
-                this.teleportInsideCooldown = 0.5f;
-                portal.cooldown = portal.maxCooldown;
-                this.cooldown = this.maxCooldown;
+                portal.teleportInsideCooldown = 0.5f + freezeCooldown;
+                this.teleportInsideCooldown = 0.5f + freezeCooldown;
+                portal.cooldown = portal.maxCooldown + freezeCooldown;
+                this.cooldown = this.maxCooldown + freezeCooldown;
                 portal.portal.Color = this.cooldownColor;
                 this.portal.Color = this.cooldownColor;
                 this.level.Session.SetFlag("portalOnCooldown" + readyColor.ToString(), true);
             }
+        }
+
+        private IEnumerator Transport(Player player, Vector2 cameraFrom) {
+            // this.AddTag(Tags.FrozenUpdate);
+            this.level.Frozen = true;
+            float transportAt = 0f;
+            Vector2 cameraTo = this.level.GetFullCameraTargetAt(player, player.Position);
+            while (transportAt < 1f) {
+                yield return null;
+                transportAt = Calc.Approach(transportAt, 1f, Engine.DeltaTime / freezeCooldown);
+                if (transportAt > 0.9f) {
+                    this.level.Camera.Position = cameraTo;
+                } else {
+                    this.level.Camera.Position = Vector2.Lerp(cameraFrom, cameraTo, Ease.CubeOut(transportAt));
+                }
+            }
+            this.level.OnEndOfFrame += delegate() {
+                // this.RemoveTag(Tags.FrozenUpdate);
+                this.level.Frozen = false;
+            };
+            yield break;
         }
 
 
@@ -336,6 +362,9 @@ namespace Celeste.Mod.OutbackHelper {
 
 
         private Color cooldownColor = new Color(1f, 0.5f, 0.5f);
+
+
+        public float freezeCooldown = 0f;
 
 
         public float teleportInsideCooldown;

--- a/Loenn/entities/portal.lua
+++ b/Loenn/entities/portal.lua
@@ -58,7 +58,8 @@ for i, j in pairs(directions) do
         data = {
             ["readyColor"] = "Purple",
             direction = i,
-            cooldownTimer = 0.0
+            cooldownTimer = 0.0,
+            freezeTimer = 0.5,
         }
     })
 end
@@ -67,7 +68,8 @@ portal.fieldOrder = {
     "x", "y",
     "direction",
     "readyColor",
-    "cooldownTimer"
+    "cooldownTimer",
+    "freezeTimer",
 }
 
 local nonDirectionalTexture = "objects/outback/portal/idle00"

--- a/Loenn/entities/portal.lua
+++ b/Loenn/entities/portal.lua
@@ -59,7 +59,7 @@ for i, j in pairs(directions) do
             ["readyColor"] = "Purple",
             direction = i,
             cooldownTimer = 0.0,
-            freezeTimer = 0.5,
+            freezeTimer = -1.0,
         }
     })
 end

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: OutbackHelper
-  Version: 1.7.3
+  Version: 1.8.0
   DLL: Code/bin/OutbackHelper.dll
   Dependencies:
     - Name: EverestCore


### PR DESCRIPTION
I have a medical condition that makes it harder for me to follow the sudden transitions of long range portals, so I made this purely as a personal assist mode. But if people find this helpful, feel free to adapt and merge this.

# Features
- Maps that use portals are unaffected unless you change the settings for the default freeze time.
- If so, when you enter a portal, the camera smoothly moves to the position it would be at the frame you exit the portal. (See the long room in the demo.)
- If the camera would only move a little, then it doesn't move during the frozen period. (See the aqua portals in the demo.)
- Each portal has a new attribute that allows map makers to override the freeze time. For example, setting it to 0 forces the original portal experience. (See the first few portals in the demo.) Maybe this way people can optimize the portal gp in their maps better?
- I also added some particle effects to guide the eyes.

# Caveats
- Spinner loading :peaceline: Unloaded spinners won't show until after the transition is finished, so it visually looks a bit janky. But unlike room transitions, I don't want to force them to load as this changes the mechanics.

https://github.com/user-attachments/assets/21bc62cc-1561-4e45-ab98-952c58ffbbc3

